### PR TITLE
HW03. Cd and Ls

### DIFF
--- a/src/main/kotlin/me/fang/kosh/process/Utils.kt
+++ b/src/main/kotlin/me/fang/kosh/process/Utils.kt
@@ -1,11 +1,7 @@
 package me.fang.kosh.process
 
 import me.fang.kosh.exceptions.ExitCalledException
-import me.fang.kosh.process.commands.Cat
-import me.fang.kosh.process.commands.Echo
-import me.fang.kosh.process.commands.Grep
-import me.fang.kosh.process.commands.Pwd
-import me.fang.kosh.process.commands.Wc
+import me.fang.kosh.process.commands.*
 
 /**
  * Запускает команду.
@@ -21,6 +17,8 @@ fun processSingleCommand(cmdWithArgs: List<String>): String = when (cmdWithArgs[
     "wc" -> Wc(cmdWithArgs).run("")
     "pwd" -> Pwd(cmdWithArgs).run("")
     "grep" -> Grep(cmdWithArgs).run("")
+    "cd" -> Cd(cmdWithArgs).run("")
+    "ls" -> Ls(cmdWithArgs).run("")
     "exit" -> throw ExitCalledException()
     else -> if (cmdWithArgs[0].contains('=')) {
         VariableAssignment(cmdWithArgs).run("")
@@ -44,6 +42,8 @@ fun processPipeline(pipeline: List<List<String>>): String = pipeline.fold("") { 
         "wc" -> Wc(cmdWithArgs).run(stdin)
         "pwd" -> Pwd(cmdWithArgs).run(stdin)
         "grep" -> Grep(cmdWithArgs).run(stdin)
+        "cd" -> Cd(cmdWithArgs).run(stdin)
+        "ls" -> Ls(cmdWithArgs).run(stdin)
         "exit" -> "" // Exit on pipeline do nothing
         else -> if (cmdWithArgs[0].contains('=')) {
             "" // In pipeline assignment do nothing

--- a/src/main/kotlin/me/fang/kosh/process/commands/Cd.kt
+++ b/src/main/kotlin/me/fang/kosh/process/commands/Cd.kt
@@ -1,0 +1,27 @@
+package me.fang.kosh.process.commands
+
+import me.fang.kosh.Environment
+import me.fang.kosh.process.KoshProcess
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+
+class Cd(override val args: List<String>) : KoshProcess {
+    override fun run(stdin: String): String {
+        val arg = args.drop(1)
+        if (arg.size > 1) {
+            throw IllegalStateException("Illegal number of arguments")
+        }
+        if (arg.size == 1) {
+            val path = Path.of(arg[0])
+            if (!path.isDirectory()) {
+                throw IllegalStateException("Not a directory")
+            }
+            if (path.isAbsolute) {
+                Environment.cwd = path
+            } else {
+                Environment.cwd = Environment.cwd.resolve(path)
+            }
+        }
+        return ""
+    }
+}

--- a/src/main/kotlin/me/fang/kosh/process/commands/Ls.kt
+++ b/src/main/kotlin/me/fang/kosh/process/commands/Ls.kt
@@ -1,0 +1,31 @@
+package me.fang.kosh.process.commands
+
+import me.fang.kosh.Environment
+import me.fang.kosh.process.KoshProcess
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Collectors
+
+class Ls(override val args: List<String>) : KoshProcess{
+    override fun run(stdin: String): String {
+        val filename = args.drop(1)
+        return if (filename.isEmpty()) {
+            getFiles(Environment.cwd)
+        } else if (filename.size == 1) {
+            getFiles(Paths.get(filename[0]))
+        } else {
+            throw IllegalStateException("Illegal number of arguments")
+        }
+    }
+
+    private fun getFiles(path: Path): String {
+        val newPath = if (!path.isAbsolute) {
+            Environment.cwd.resolve(path)
+        } else {
+            path
+        }
+
+        return Files.walk(newPath, 1).map{ x -> x.fileName.toString()}.collect(Collectors.joining(" ")) + "\n"
+    }
+}

--- a/src/test/kotlin/me/fang/kosh/process/commands/CdTest.kt
+++ b/src/test/kotlin/me/fang/kosh/process/commands/CdTest.kt
@@ -1,0 +1,23 @@
+package me.fang.kosh.process.commands
+
+import me.fang.kosh.Environment
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CdTest {
+    @Test
+    fun cdTest() {
+        assertEquals("", Cd(listOf("cd")).run(""))
+        Cd(listOf("cd", "..")).run("")
+        assertEquals(Path.of("..").toAbsolutePath().toString(), Environment.cwd.toString())
+        assertFailsWith<Exception>{ Cd(listOf("cd", "..", "/")).run("") }
+        val file = Files.createTempFile("tmp_file", ".txt")
+        assertFailsWith<Exception> { Cd(listOf("cd", file.toAbsolutePath().toString())).run("") }
+        val dir = Files.createTempDirectory("tmp_dir")
+        Cd(listOf("cd", dir.toAbsolutePath().toString())).run("")
+        assertEquals(dir.toAbsolutePath().toString(), Environment.cwd.toString())
+    }
+}

--- a/src/test/kotlin/me/fang/kosh/process/commands/LsTest.kt
+++ b/src/test/kotlin/me/fang/kosh/process/commands/LsTest.kt
@@ -1,0 +1,30 @@
+package me.fang.kosh.process.commands
+
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import kotlin.collections.ArrayList
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class LsTest {
+    @Test
+    fun lsTest() {
+        val testDir = Files.createTempDirectory("testDir")
+        val expectedResult = ArrayList<String>()
+        expectedResult.add(testDir.fileName.toString())
+        val files = listOf("file1", "file2", "file3", "file4")
+        for (file in files) {
+            expectedResult.add(Files.createTempFile(testDir, file, ".txt").fileName.toString())
+        }
+
+        val output = Ls(listOf("ls", testDir.toAbsolutePath().toString())).run("").split(" ").toMutableList()
+        output[output.size - 1] = output.last().trim()
+
+        assertTrue(expectedResult.size == output.size && expectedResult.containsAll(output) && output.containsAll(expectedResult))
+    }
+
+    @Test
+    fun lsTestException() {
+        assertFailsWith<Exception> { Ls(listOf("ls", "0", "1")).run("") }
+    }
+}


### PR DESCRIPTION
Новые команды было удобно добавлять. Для этого достаточно было в методах processSingleCommand и processPipeline добавить обработку команды ls и cd, чтобы не вызывались внешние команды. И реализовать два класса, которые надо было отнаследовать от интерфейса KoshProcess. Также удобно было, что архитектура уже была готова к добавлению команд cd и ls, потому что в Environment уже хранилась текущая директория. 
Наверное, минусы архитектуры, это то что Environment это сингелтон. И то что команды принимают на вход и отдают  на выход  строку, т.е. команды не смогут работать с бесконечным вводом/выводом. 